### PR TITLE
Bugsnag sourcemap uploader options package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This is lazy and an error is raised if a wrong options object is passed.
 
 ## Uploader
 
-Add a `bugsnag` node in the root `package.json` of your application to set few parameters:
+Add a `bugsnag/upload` node in the root `package.json` of your application to set few parameters:
 
 ```json
 {
@@ -84,12 +84,7 @@ Add a `bugsnag` node in the root `package.json` of your application to set few p
 }
 ```
 
-- **apiKey**: is used in order to authenticate calls to the upload API.
-- **minifiedUrl**: [docs here](https://docs.bugsnag.com/api/js-source-map-upload/#uploading-source-maps).
-- **sourceMap**: Local path to your source map file.
-- **minifiedFile**: Local path to your minified bundle file.
-
-**Note:** all the properties are mandatory
+You can set any [`bugsnag-sourcemap` option](https://docs.bugsnag.com/build-integrations/js/#source-map-uploader), **apiKey** is the only required.
 
 And then you run the uploader from command line:
 

--- a/src/bin/decoders.ts
+++ b/src/bin/decoders.ts
@@ -1,14 +1,33 @@
 import * as t from 'io-ts';
 
+type UploadOpts = t.TypeOf<typeof UploadOpts>;
+const UploadOpts = t.intersection(
+  [
+    t.type({
+      apiKey: t.string
+    }),
+    t.partial({
+      appVersion: t.string,
+      directory: t.union([t.boolean, t.string]),
+      endpoint: t.string,
+      minifiedFile: t.string,
+      minifiedUrl: t.string,
+      overwrite: t.boolean,
+      projectRoot: t.string,
+      sourceMap: t.string,
+      sources: t.record(t.string, t.string),
+      uploadSources: t.boolean
+    })
+  ],
+  'upload'
+);
+
 interface BugsnagPkgConfig extends t.TypeOf<typeof BugsnagPkgConfig> {}
 const BugsnagPkgConfig = t.type(
   {
-    apiKey: t.string,
-    minifiedUrl: t.string,
-    sourceMap: t.string,
-    minifiedFile: t.string
+    upload: UploadOpts
   },
-  'Bugsnag config in package.json'
+  'bugsnag'
 );
 
 export interface Package extends t.TypeOf<typeof Package> {}

--- a/src/bin/read-pkg.ts
+++ b/src/bin/read-pkg.ts
@@ -6,7 +6,8 @@ import readPkgUp, {NormalizedReadResult as RPUPackage} from 'read-pkg-up';
 import {Package} from './decoders';
 
 const decodePkg = (json: unknown): Either<Error, Package> =>
-  Package.decode(json).mapLeft(errors => new Error(failure(errors).join('\n')));
+  // only takes the first failure in order to not mess error messages
+  Package.decode(json).mapLeft(errors => new Error(failure(errors)[0]));
 
 const readPkgUpTE = new TaskEither<Error, RPUPackage['package']>(
   new Task(() =>

--- a/src/bin/upload.ts
+++ b/src/bin/upload.ts
@@ -12,13 +12,14 @@ import {Trace, trace} from './trace';
 
 const sequenceTE = sequenceT(taskEither);
 
-const toOptions = ({version, bugsnag}: Package): BugsnagSourceMapsConfig => ({
-  apiKey: bugsnag.apiKey,
-  appVersion: version,
-  sourceMap: bugsnag.sourceMap,
-  minifiedUrl: bugsnag.minifiedUrl,
-  minifiedFile: bugsnag.minifiedFile,
+const DEFAULT_OPTS: Omit<BugsnagSourceMapsConfig, 'apiKey'> = {
   overwrite: true
+};
+
+const toOptions = ({version, bugsnag}: Package): BugsnagSourceMapsConfig => ({
+  ...DEFAULT_OPTS,
+  ...bugsnag.upload,
+  appVersion: version
 });
 
 // --- Capabilities

--- a/test/bin/read-pkg.spec.ts
+++ b/test/bin/read-pkg.spec.ts
@@ -12,10 +12,12 @@ test('readPkg should retrieve info from package.json', () => {
       name: 'test-pkg',
       version: '0.1.0',
       bugsnag: {
-        apiKey: 'TEST-API-KEY',
-        minifiedUrl: 'https://my.application.com/bundle.js',
-        sourceMap: './path/to/bundle.js.map',
-        minifiedFile: './path/to/bundle.js'
+        upload: {
+          apiKey: 'TEST-API-KEY',
+          minifiedUrl: 'https://my.application.com/bundle.js',
+          sourceMap: './path/to/bundle.js.map',
+          minifiedFile: './path/to/bundle.js'
+        }
       }
     }
   });
@@ -24,10 +26,12 @@ test('readPkg should retrieve info from package.json', () => {
     name: 'test-pkg',
     version: '0.1.0',
     bugsnag: {
-      apiKey: 'TEST-API-KEY',
-      minifiedUrl: 'https://my.application.com/bundle.js',
-      sourceMap: './path/to/bundle.js.map',
-      minifiedFile: './path/to/bundle.js'
+      upload: {
+        apiKey: 'TEST-API-KEY',
+        minifiedUrl: 'https://my.application.com/bundle.js',
+        sourceMap: './path/to/bundle.js.map',
+        minifiedFile: './path/to/bundle.js'
+      }
     }
   });
 });
@@ -41,11 +45,11 @@ test('readPkg should fail if it cannot find a package.json', () => {
 });
 
 test('readPkg should fail if package.json has not valid data', () => {
-  readPkgUpM.mockResolvedValue({package: {version: '1.0.0'}});
+  readPkgUpM.mockResolvedValue({package: {version: '1.0.0', bugsnag: {}}});
 
   return expect(result(readPkg)).rejects.toEqual(
     new Error(
-      'Invalid value undefined supplied to : Package/bugsnag: Bugsnag config in package.json'
+      'Invalid value undefined supplied to : Package/bugsnag: bugsnag/upload: upload/0: { apiKey: string }'
     )
   );
 });

--- a/test/bin/upload.spec.ts
+++ b/test/bin/upload.spec.ts
@@ -78,10 +78,13 @@ const testCap: Capabilities = {
   readPkg: taskEither.of({
     version: '0.1.0',
     bugsnag: {
-      apiKey: 'TEST-API-KEY',
-      minifiedUrl: 'https://my.application.com/bundle.js',
-      sourceMap: './path/to/bundle.js.map',
-      minifiedFile: './path/to/bundle.js'
+      upload: {
+        apiKey: 'TEST-API-KEY',
+        minifiedUrl: 'https://my.application.com/bundle.js',
+        sourceMap: './path/to/bundle.js.map',
+        minifiedFile: './path/to/bundle.js',
+        directory: './some/path'
+      }
     }
   }),
   uploadSourceMap: jest.fn(_ => taskEither.of(undefined)),
@@ -94,5 +97,6 @@ const OPTS = {
   sourceMap: './path/to/bundle.js.map',
   minifiedUrl: 'https://my.application.com/bundle.js',
   minifiedFile: './path/to/bundle.js',
+  directory: './some/path',
   overwrite: true
 };

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -2,9 +2,11 @@
   "name": "test-pkg",
   "version": "0.1.0",
   "bugsnag": {
-    "apiKey": "TEST-API-KEY",
-    "minifiedUrl": "https://my.application.com/bundle.js",
-    "sourceMap": "bundle.js.map",
-    "minifiedFile": "bundle.js"
+    "upload": {
+      "apiKey": "TEST-API-KEY",
+      "minifiedUrl": "https://my.application.com/bundle.js",
+      "sourceMap": "bundle.js.map",
+      "minifiedFile": "bundle.js"
+    }
   }
 }

--- a/typings/bugsnag-sourcemaps/index.d.ts
+++ b/typings/bugsnag-sourcemaps/index.d.ts
@@ -1,34 +1,49 @@
 declare module 'bugsnag-sourcemaps' {
+  /**
+   * Provide options to the source map uploader.
+   * @see https://docs.bugsnag.com/build-integrations/js/#source-map-uploader
+   */
   export interface BugsnagSourceMapsConfig {
     /**
-     * your Bugsnag API key
+     * Your Bugsnag API key
      */
     apiKey: string;
 
     /**
-     * file path of the source map on the current machine
-     */
-    sourceMap: string;
-
-    /**
-     * the URL of your bundled assets (as the browser will see them). Note that this can include wildcards in case your JS is served at multiple URLs.
-     */
-    minifiedUrl?: string;
-
-    /**
-     * the version of the application you are building (this should match the appVersion configured in your notifier)
+     * The version of the application you are building (this should match the `appVersion` configured in your notifier).
+     * If `appVersion` is not supplied, the `version` property from the nearest `package.json` will be used.
      */
     appVersion?: string;
 
     /**
-     * file path of the minified file on the current machine
+     * Whether to scan `projectRoot` for source maps, uploading them all.
+     * If a string is provided, it searches that path instead.
+     * This option makes `minifiedFile`, `minifiedUrl` and `sourceMap` redundant.
+     * This option is only for Node projects where one source map is created per source file.
+     */
+    directory?: boolean | string;
+
+    /**
+     * Defaults to `https://upload.bugsnag.com`.
+     * If you are using Bugsnag On-premise use your Bugsnag Upload API endpoint
+     */
+    endpoint?: string;
+
+    /**
+     * File path of the minified file on the current machine
      */
     minifiedFile?: string;
 
     /**
-     * object paths to original source file locations on the current machine. This option is useful when the sources are not included in the source map.
+     * The URL of your bundled assets (as the browser will see them).
+     * Note that this can [include wildcards](https://docs.bugsnag.com/api/js-source-map-upload/#do-you-support-partial-matching-wildcards-for-the-minified-url) in case your JS is served at multiple URLs.
      */
-    sources?: object;
+    minifiedUrl?: string;
+
+    /**
+     * Whether you want to overwrite previously uploaded source maps
+     */
+    overwrite?: boolean;
 
     /**
      * The root path to remove from absolute paths
@@ -36,19 +51,20 @@ declare module 'bugsnag-sourcemaps' {
     projectRoot?: string;
 
     /**
+     * File path of the source map on the current machine
+     */
+    sourceMap?: string;
+
+    /**
+     * Object paths to original source file locations on the current machine.
+     * This option is useful when the sources are not included in the source map.
+     */
+    sources?: Record<string, string>;
+
+    /**
      * If the source content was not included in the source map, this option will retrieve the sources and attach them
      */
     uploadSources?: boolean;
-
-    /**
-     * whether you want to overwrite previously uploaded source maps
-     */
-    overwrite?: boolean;
-
-    /**
-     * Defaults to https://upload.bugsnag.com. If you are using Bugsnag On-premise use your Bugsnag Upload API endpoint
-     */
-    endpoint?: string;
   }
 
   export function upload(config: BugsnagSourceMapsConfig): Promise<void>;


### PR DESCRIPTION
This PR allow users to set any kind of `bugsnag-sourcemap` option in the `bugsnag/upload` field of package.json

resolves #109 