### PR TITLE
Add @types/webpack-bugsnag-plugins and bump to v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 > - [_Feature_](https://github.com/contactlab/contactsnag/labels/feature)
 > - [_Polish_](https://github.com/contactlab/contactsnag/labels/polish)
 
+## [3.0.1](https://github.com/contactlab/gluex/releases/tag/v3.0.1)
+
+**Dependencies:**
+
+- `[feature]` Add and expose webpack plugin typings (#126)
+
 ## [3.0.0](https://github.com/contactlab/gluex/releases/tag/v3.0.0)
 
 **Feature:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contactsnag",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -459,6 +459,11 @@
         "@types/yargs": "^12.0.9"
       }
     },
+    "@types/anymatch": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
+      "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
+    },
     "@types/babel__core": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -543,8 +548,7 @@
     "@types/node": {
       "version": "12.6.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
-      "dev": true
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -556,6 +560,39 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/tapable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
+      "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ=="
+    },
+    "@types/uglify-js": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
+      "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "@types/webpack": {
+      "version": "4.32.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.32.1.tgz",
+      "integrity": "sha512-9n38CBx9uga1FEAdTipnt0EkbKpsCJFh7xJb1LE65FFb/A6OOLFX022vYsGC1IyVCZ/GroNg9u/RMmlDxGcLIw==",
+      "requires": {
+        "@types/anymatch": "*",
+        "@types/node": "*",
+        "@types/tapable": "*",
+        "@types/uglify-js": "*",
+        "source-map": "^0.6.0"
+      }
+    },
+    "@types/webpack-bugsnag-plugins": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-bugsnag-plugins/-/webpack-bugsnag-plugins-1.4.0.tgz",
+      "integrity": "sha512-ux/SJh3bnnKTtPEt9KXJPMxk51Vzm10ZThXcGKizjG2DiURljEhDExGOzI1kFHO/G4OBGtcpD4eQqcK+k9+tXA==",
+      "requires": {
+        "@types/webpack": "*"
+      }
     },
     "@types/yargs": {
       "version": "12.0.12",
@@ -5525,8 +5562,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contactsnag",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Bugsnag utilities for Contactlab's applications",
   "main": "lib/index.js",
   "module": "lib/es6/index.js",
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@bugsnag/js": "6.3.2",
+    "@types/webpack-bugsnag-plugins": "^1.4.0",
     "bugsnag-sourcemaps": "1.2.1",
     "chalk": "2.4.2",
     "fp-ts": "^1.19.0",


### PR DESCRIPTION
This PR adds as production dependency [`@types/webpack-bugsnag-plugins`](https://www.npmjs.com/package/@types/webpack-bugsnag-plugins)

resolves #126 