### PR TITLE
Fix set options validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 > - [_Feature_](https://github.com/contactlab/contactsnag/labels/feature)
 > - [_Polish_](https://github.com/contactlab/contactsnag/labels/polish)
 
+## [4.0.1](https://github.com/contactlab/gluex/releases/tag/v4.0.1)
+
+**Bug:**
+
+- `[internal]` Fix set options validation #134
+
 ## [4.0.0](https://github.com/contactlab/gluex/releases/tag/v4.0.0)
 
 **Breaking:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contactsnag",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contactsnag",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Bugsnag utilities for Contactlab's applications",
   "main": "lib/index.js",
   "module": "lib/es6/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -130,7 +130,7 @@ function setOptions(
   opts: AnyBugsnagConfig
 ): (client: Started) => IOEither<Error, Bugsnag.Client> {
   return v =>
-    fromEither(validate(merge(v.bugsnag.config, opts))).chain(o =>
+    fromEither(validate({apiKey: v.bugsnag.config.apiKey, ...opts})).chain(o =>
       rightIO(new IO(() => v.bugsnag.setOptions(o)))
     );
 }


### PR DESCRIPTION
This PR fixes the validation process of the provided options for `setOptions()` method.

fixes #134 