### PR TITLE
fix husky install on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "postinstall": "husky install",
+    "postpublish": "pinst --enable",
     "check": "tsc --noEmit",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "pretest": "npm run check && npm run lint",
@@ -35,7 +36,7 @@
     "build": "npm run build:cjs && npm run build:es6",
     "build:cjs": "tsc -p ./tsconfig.build.json",
     "build:es6": "tsc -p ./tsconfig.build-es6.json",
-    "prepublishOnly": "npm test && npm run build"
+    "prepublishOnly": "npm test && npm run build && pinst --disable"
   },
   "peerDependencies": {
     "fp-ts": "^2.8.0",


### PR DESCRIPTION
This PR:

- fixes `postinstall` script: it will run `husky install` only on local development